### PR TITLE
Improve module reload error logging

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -19,53 +19,71 @@
 # SPDX-License-Identifier: MIT
 
 import sys
+import importlib
+import logging
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 # Get the directory path of the current script
 add_on_directory = Path(__file__).parent
 
 # Append the dependencies directories to the path so we can access the bundled python modules
 # If dependencies_public doesn't exist yet, the user is prompted to install them before using the plugin
-sys.path.append(str(add_on_directory / "dependencies_private"))
-sys.path.append(str(add_on_directory / "dependencies_public"))
+dependencies_private = add_on_directory / "dependencies_private"
+dependencies_public = add_on_directory / "dependencies_public"
 
-if "bpy" in locals():
-    # Imports have run before. Need to reload the imported modules
-    import importlib
+for dep_path in (dependencies_private, dependencies_public):
+    dep_str = str(dep_path)
+    if dep_str not in sys.path:
+        sys.path.append(dep_str)
 
-    if "event_loop" in locals():
-        importlib.reload(event_loop)
-    if "status_indicators" in locals():
-        importlib.reload(status_indicators)
-    if "roblox_properties" in locals():
-        importlib.reload(roblox_properties)
-    if "oauth2_login_operators" in locals():
-        importlib.reload(oauth2_login_operators)
-    if "RBX_OT_upload" in locals():
-        importlib.reload(RBX_OT_upload)
-    if "RbxOAuth2Client" in locals():
-        importlib.reload(RbxOAuth2Client)
-    if "get_selected_objects" in locals():
-        importlib.reload(get_selected_objects)
-    if "constants" in locals():
-        importlib.reload(constants)
-    if "creator_details" in locals():
-        importlib.reload(creator_details)
-    if "RBX_OT_install_dependencies" in locals():
-        importlib.reload(RBX_OT_install_dependencies)
-
-import bpy
-from bpy.app.handlers import persistent
-from bpy.types import Panel, AddonPreferences
-from bpy.props import (
-    StringProperty,
-    PointerProperty,
-    FloatProperty,
-    IntProperty,
-    BoolProperty,
+MODULES_TO_RELOAD = (
+    "event_loop",
+    "status_indicators",
+    "roblox_properties",
+    "oauth2_login_operators",
+    "RBX_OT_upload",
+    "RbxOAuth2Client",
+    "get_selected_objects",
+    "constants",
+    "creator_details",
+    "RBX_OT_install_dependencies",
 )
 
-import traceback
+
+def reload_modules(module_names: tuple) -> None:
+    """Safely reload specified modules with logging."""
+
+    for name in module_names:
+        module = globals().get(name)
+        if module is None:
+            continue
+
+        try:
+            importlib.reload(module)
+            logger.debug("Successfully reloaded: %s", name)
+        except Exception as e:  # pragma: no cover - best effort
+            logger.warning("Failed to reload %s: %s", name, e, exc_info=True)
+
+
+if "bpy" in locals():
+    reload_modules(MODULES_TO_RELOAD)
+
+try:
+    import bpy
+    from bpy.app.handlers import persistent
+    from bpy.types import Panel, AddonPreferences
+    from bpy.props import (
+        StringProperty,
+        PointerProperty,
+        FloatProperty,
+        IntProperty,
+        BoolProperty,
+    )
+except ImportError as e:  # pragma: no cover - cannot happen outside Blender
+    logger.error("Failed to import Blender modules: %s", e)
+    raise
 
 bl_info = {
     "name": "Upload to Roblox",

--- a/lib/upload_operator.py
+++ b/lib/upload_operator.py
@@ -18,47 +18,53 @@
 
 # SPDX-License-Identifier: MIT
 
-if "bpy" in locals():
-    # Imports have run before. Need to reload the imported modules
-    import importlib
+import importlib
+import logging
+import traceback
 
-    if "get_selected_objects" in locals():
-        importlib.reload(get_selected_objects)
-    if "upload_blocking_issues" in locals():
-        importlib.reload(upload_blocking_issues)
-    if "creator_details" in locals():
-        importlib.reload(creator_details)
-    if "status_indicators" in locals():
-        importlib.reload(status_indicators)
-    if "export_fbx" in locals():
-        importlib.reload(export_fbx)
-    if "get_add_on_preferences" in locals():
-        importlib.reload(get_add_on_preferences)
-    if "RbxOAuth2Client" in locals():
-        importlib.reload(RbxOAuth2Client)
-    if "str_to_int" in locals():
-        importlib.reload(str_to_int)
-    if "constants" in locals():
-        importlib.reload(constants)
-    if "AssetsUploadClient" in locals():
-        importlib.reload(AssetsUploadClient)
-    if "AssetsCreator" in locals():
-        importlib.reload(AssetsCreator)
-    if "AssetType" in locals():
-        importlib.reload(AssetType)
-    if "openapi_client" in locals():
-        importlib.reload(openapi_client)
-    if "aiolimiter" in locals():
-        importlib.reload(aiolimiter)
-    if "extract_exception_message" in locals():
-        importlib.reload(extract_exception_message)
-    if "event_loop" in locals():
-        importlib.reload(event_loop)
+logger = logging.getLogger(__name__)
+
+MODULES_TO_RELOAD = (
+    "get_selected_objects",
+    "upload_blocking_issues",
+    "creator_details",
+    "status_indicators",
+    "export_fbx",
+    "get_add_on_preferences",
+    "RbxOAuth2Client",
+    "str_to_int",
+    "constants",
+    "AssetsUploadClient",
+    "AssetsCreator",
+    "AssetType",
+    "openapi_client",
+    "aiolimiter",
+    "extract_exception_message",
+    "event_loop",
+)
+
+
+def reload_modules(module_names: tuple) -> None:
+    """Safely reload specified modules with logging."""
+
+    for name in module_names:
+        module = globals().get(name)
+        if module is None:
+            continue
+
+        try:
+            importlib.reload(module)
+            logger.debug("Successfully reloaded: %s", name)
+        except Exception as e:  # pragma: no cover - best effort
+            logger.warning("Failed to reload %s: %s", name, e, exc_info=True)
+
+
+if "bpy" in locals():
+    reload_modules(MODULES_TO_RELOAD)
 
 import bpy
 from bpy.types import Operator
 
-import traceback
 from tempfile import TemporaryDirectory
 from pathlib import Path
 


### PR DESCRIPTION
## Summary
- create `reload_modules` helper with logging
- reload development modules via helper in both main entrypoint and upload operator
- protect Blender imports with error logging

## Testing
- `black __init__.py lib/upload_operator.py`


------
https://chatgpt.com/codex/tasks/task_e_6879a14c94408331a8427c86fea46d87