### PR TITLE
Add basic HTML page for live stream

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Monster Game Live</title>
+  <style>
+    body { font-family: Arial, sans-serif; margin: 2rem; background: #111; color: #eee; }
+    a.button {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      background: #e81c4f;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 4px;
+    }
+    a.button:hover { background: #c81a45; }
+  </style>
+</head>
+<body>
+  <h1>Monster Game</h1>
+  <p>Welcome to the Monster Game livestream hub.</p>
+  <section id="tiktok-live">
+    <h2>🔴 Now Streaming on TikTok</h2>
+    <p>
+      <!-- Replace "your-tiktok" with your actual TikTok handle -->
+      <a class="button" href="https://www.tiktok.com/@your-tiktok/live" target="_blank" rel="noopener noreferrer">Watch Live</a>
+    </p>
+  </section>
+</body>
+</html>

--- a/lib/extract_exception_message.py
+++ b/lib/extract_exception_message.py
@@ -19,9 +19,9 @@
 # SPDX-License-Identifier: MIT
 
 """
-    Some API responses contain a string body, and others contain a json
-    body with a Message entry. This returns the message, regardless of either
-    response type.
+Some API responses contain a string body, and others contain a json
+body with a Message entry. This returns the message, regardless of either
+response type.
 """
 
 import json

--- a/lib/get_selected_objects.py
+++ b/lib/get_selected_objects.py
@@ -19,8 +19,8 @@
 # SPDX-License-Identifier: MIT
 
 """
-    Returns objects selected in any outliner by the user, only including "uploadable" objects.
-    For a collection to be selectable, it must contain an uploadable descendant.
+Returns objects selected in any outliner by the user, only including "uploadable" objects.
+For a collection to be selectable, it must contain an uploadable descendant.
 """
 
 import bpy


### PR DESCRIPTION
## Summary
- add `index.html` to host a TikTok livestream link
- run `black` to keep formatting consistent

## Testing
- `black --check --diff --color .`

------
https://chatgpt.com/codex/tasks/task_e_6882dbedad288331861b797d88f69284