### PR TITLE
Fix str_to_int error handling

### DIFF
--- a/lib/str_to_int.py
+++ b/lib/str_to_int.py
@@ -20,9 +20,14 @@
 
 
 def str_to_int(string, *, default=None):
-    """Returns the integer value of the string if the string is numeric,
-    otherwise returns default"""
+    """Return ``int(string)`` if possible, otherwise ``default``.
+
+    Any ``TypeError`` or ``ValueError`` raised during conversion
+    results in ``default`` being returned instead of propagating an
+    exception.
+    """
+
     try:
         return int(string)
-    except TypeError:
+    except (TypeError, ValueError):
         return default


### PR DESCRIPTION
## Summary
- catch ValueError as well as TypeError in `str_to_int`
- return default on invalid numeric strings

## Testing
- `black --check lib/str_to_int.py`


------
https://chatgpt.com/codex/tasks/task_e_687beee14d0483319d5bd36d5f09c41f