### PR TITLE
Ensure dependency cleanup uses rmtree

### DIFF
--- a/lib/install_dependencies.py
+++ b/lib/install_dependencies.py
@@ -34,6 +34,7 @@ import subprocess
 import os
 import ensurepip
 from pathlib import Path
+import shutil
 import traceback
 import asyncio
 
@@ -63,7 +64,7 @@ class RBX_OT_install_dependencies(Operator):
                 rbx.is_finished_installing_dependencies = True
                 rbx.needs_restart = True
             except Exception as exception:
-                dependencies_public_directory.rmdir()
+                shutil.rmtree(dependencies_public_directory, ignore_errors=True)
                 traceback.print_exception(exception)
 
         rbx.is_installing_dependencies = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import sys
+import types
+from pathlib import Path
+
+bpy_module = types.ModuleType("bpy")
+bpy_module.types = types.SimpleNamespace(
+    Operator=object,
+    Panel=object,
+    AddonPreferences=object,
+)
+bpy_module.app = types.SimpleNamespace(handlers=types.SimpleNamespace(persistent=lambda f: f))
+bpy_module.utils = types.SimpleNamespace(register_class=lambda x: None, unregister_class=lambda x: None)
+bpy_module.props = types.SimpleNamespace(
+    StringProperty=lambda *a, **k: None,
+    PointerProperty=lambda *a, **k: None,
+    FloatProperty=lambda *a, **k: None,
+    IntProperty=lambda *a, **k: None,
+    BoolProperty=lambda *a, **k: None,
+)
+
+sys.modules.setdefault("bpy", bpy_module)
+sys.modules.setdefault("bpy.types", bpy_module.types)
+sys.modules.setdefault("bpy.app", bpy_module.app)
+sys.modules.setdefault("bpy.app.handlers", bpy_module.app.handlers)
+sys.modules.setdefault("bpy.utils", bpy_module.utils)
+sys.modules.setdefault("bpy.props", bpy_module.props)
+
+sys.modules.setdefault("__init__", types.ModuleType("__init__"))
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_install_dependencies.py
+++ b/tests/test_install_dependencies.py
@@ -1,0 +1,45 @@
+import pytest
+
+from lib import install_dependencies
+from lib import event_loop
+
+
+class DummyRBX:
+    def __init__(self):
+        self.is_installing_dependencies = False
+        self.is_finished_installing_dependencies = False
+        self.needs_restart = False
+
+
+class DummyWindowManager:
+    def __init__(self):
+        self.rbx = DummyRBX()
+
+
+class DummyContext:
+    def __init__(self):
+        self.window_manager = DummyWindowManager()
+
+
+class DummyTask:
+    def result(self):
+        raise Exception("boom")
+
+
+def test_dependencies_directory_removed_on_error(tmp_path, monkeypatch):
+    tmp_dir = tmp_path / "deps"
+    tmp_dir.mkdir()
+    (tmp_dir / "file.txt").write_text("data")
+    monkeypatch.setattr(install_dependencies, "dependencies_public_directory", tmp_dir)
+
+    plugin = install_dependencies.RBX_OT_install_dependencies()
+    ctx = DummyContext()
+
+    def fake_submit(async_coroutine, done_callback):
+        done_callback(DummyTask())
+
+    monkeypatch.setattr(event_loop, "submit", fake_submit)
+
+    plugin.execute(ctx)
+
+    assert not tmp_dir.exists()


### PR DESCRIPTION
## Summary
- import `shutil` in `install_dependencies`
- remove partially-populated dependency directory with `shutil.rmtree`
- add tests verifying removal on installation error

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687beee1a8c883319ca64f548600a186